### PR TITLE
Handle JSON decode error

### DIFF
--- a/pageview_client/clients.py
+++ b/pageview_client/clients.py
@@ -95,7 +95,10 @@ class TrendingClient(BasePageviewClient):
             url += "&limit={}".format(limit)
         response = requests.get(url)
         if response.ok:
-            parsed_data = json.loads(response.content)
+            try:
+                parsed_data = json.loads(response.content)
+            except (ValueError, TypeError):
+                return []
             trend_data = [Trend(**obj) for obj in parsed_data]
             self.data = dict([(t.content_id, t) for t in trend_data])
             return self.data.keys()

--- a/tests/test_trending_client.py
+++ b/tests/test_trending_client.py
@@ -10,25 +10,47 @@ class Response(object):
     pass
 
 
-mock_content = json.dumps([{
-    "content_id": 2,
-    "score": 100
-}, {
-    "content_id": 0,
-    "score": 97
-}, {
-    "content_id": 1,
-    "score": 96
-}])
-mock_response = Response()
-mock_response.ok = True
-mock_response.content = mock_content
-requests.get = MagicMock(return_value=mock_response)
-
-
 def test_trendingclient_get():
+
+    mock_content = json.dumps([{
+        "content_id": 2,
+        "score": 100
+    }, {
+        "content_id": 0,
+        "score": 97
+    }, {
+        "content_id": 1,
+        "score": 96
+    }])
+    mock_response = Response()
+    mock_response.ok = True
+    mock_response.content = mock_content
+    requests.get = MagicMock(return_value=mock_response)
+
     client = TrendingClient("example.com", "hello.json")
     content_ids = client.get("example")
     assert len(content_ids) == 3
     for cid in (2, 0, 1):
         assert cid in content_ids
+
+
+def test_trendingclient_get_bad_json_value_error():
+
+    mock_response = Response()
+    mock_response.ok = True
+    mock_response.content = 'Not JSON!'
+    requests.get = MagicMock(return_value=mock_response)
+
+    client = TrendingClient("example.com", "hello.json")
+    assert not client.get("example")
+
+
+def test_trendingclient_get_bad_json_type_error():
+
+    mock_response = Response()
+    mock_response.ok = True
+    mock_response.content = None
+    requests.get = MagicMock(return_value=mock_response)
+
+    client = TrendingClient("example.com", "hello.json")
+    assert not client.get("example")


### PR DESCRIPTION
Prevents client crash, though root server cause needs to be addressed.

@benghaziboy 
